### PR TITLE
6 improve usestringbufferforstringappends to report on variable declaration

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferForStringAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferForStringAppendsRule.java
@@ -45,7 +45,7 @@ public class UseStringBufferForStringAppendsRule extends AbstractJavaRule {
 
         // Remember how often we the variable has been used
         int usageCounter = 0;
-
+        boolean isViolationReported = false;
         for (NameOccurrence no : node.getUsages()) {
             Node name = no.getLocation();
             ASTStatementExpression statement = name.getFirstParentOfType(ASTStatementExpression.class);
@@ -89,12 +89,12 @@ public class UseStringBufferForStringAppendsRule extends AbstractJavaRule {
                         if (assignmentOperator != null && assignmentOperator.isCompound()) {
                             if (isWithinLoop(name)) {
                                 // always report within a loop
-                                addViolation(data, assignmentOperator);
+                                isViolationReported = true;
                             } else {
                                 usageCounter++;
                                 if (usageCounter > 1) {
                                     // only report, if it is not the first time
-                                    addViolation(data, assignmentOperator);
+                                    isViolationReported = true;
                                 }
                             }
                         }
@@ -102,21 +102,25 @@ public class UseStringBufferForStringAppendsRule extends AbstractJavaRule {
                         if (assignmentOperator != null && !assignmentOperator.isCompound()) {
                             if (isWithinLoop(name)) {
                                 // always report within a loop
-                                addViolation(data, assignmentOperator);
+                                isViolationReported = true;
                             } else {
                                 usageCounter++;
                                 if (usageCounter > 1) {
                                     // only report, if it is not the first time
-                                    addViolation(data, assignmentOperator);
+                                    isViolationReported = true;
                                 }
                             }
                         } else if (assignmentOperator != null && assignmentOperator.isCompound()
                                 && usageCounter >= 1) {
-                            addViolation(data, assignmentOperator);
+                            isViolationReported = true;
                         }
                     }
                 }
             }
+        }
+        // only report on variable declaration
+        if (isViolationReported) {
+            addViolation(data, node.getNameDeclaration().getNode());
         }
         return data;
     }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/UseStringBufferForStringAppends.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/UseStringBufferForStringAppends.xml
@@ -568,4 +568,23 @@ public class UseStringBufferForStringAppendsFP {
             }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>reference self inside for loop and outside</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private void bar() {
+        String result = "";
+        for (int i = 0; i < 10; i++) {
+            result = result + i;
+            result += i;
+        }
+        result = result + i;
+        result = result + i;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/UseStringBufferForStringAppends.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/UseStringBufferForStringAppends.xml
@@ -7,7 +7,7 @@
     <test-code>
         <description>failure case</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>7</expected-linenumbers>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 package xxx;
 public class Foo {
@@ -48,7 +48,7 @@ public class Foo {
     <test-code>
         <description>compound append, should only report 1 failure</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>5</expected-linenumbers>
+        <expected-linenumbers>3</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -63,7 +63,7 @@ public class Foo {
     <test-code>
         <description>failure case, constructor</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>6</expected-linenumbers>
+        <expected-linenumbers>3</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public Foo() {
@@ -79,7 +79,7 @@ public class Foo {
     <test-code>
         <description>static failure case</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>6</expected-linenumbers>
+        <expected-linenumbers>3</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     static {
@@ -94,8 +94,8 @@ public class Foo {
 
     <test-code>
         <description>reference self inside for loop</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>5,6</expected-linenumbers>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     private void bar() {
@@ -186,8 +186,8 @@ public class Foo {
 
     <test-code>
         <description>violation: concat to String in for/while loop</description>
-        <expected-problems>5</expected-problems>
-        <expected-linenumbers>9,13,20,22,29</expected-linenumbers>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>6,17,26</expected-linenumbers>
         <code><![CDATA[
 import java.util.*;
 
@@ -325,8 +325,8 @@ public class ConcatInLoop {
 
     <test-code>
         <description>violation: various concats in loop</description>
-        <expected-problems>5</expected-problems>
-        <expected-linenumbers>9,11,13,14,15</expected-linenumbers>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
         <code><![CDATA[
 import java.util.*;
 
@@ -413,7 +413,7 @@ public class ConcatInLoop {
     <test-code>
         <description>violation: concat to String in do-loop</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>10</expected-linenumbers>
+        <expected-linenumbers>6</expected-linenumbers>
         <code><![CDATA[
 import java.util.*;
 
@@ -434,7 +434,7 @@ public class ConcatInLoop {
     <test-code>
         <description>violation: concat to String field in loop</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>10</expected-linenumbers>
+        <expected-linenumbers>5</expected-linenumbers>
         <code><![CDATA[
 import java.util.*;
 
@@ -541,7 +541,7 @@ public class UseStringBufferForStringAppendsFP {
     <test-code>
         <description>Test new rule example</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>6</expected-linenumbers>
+        <expected-linenumbers>3</expected-linenumbers>
         <code><![CDATA[
             public class Foo {
                 String inefficientConcatenation() {


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
Improved UseStringBufferForStringAppends rule to report on variable declaration instead of on each concatenation.
Fixed 10 tests that are related to the new changes.
Added new test to increase the code coverage.
## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #6 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

