### PR TITLE
11 rename rule methodargumentcouldbefinal to formalparametercouldbefinal

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FormalArgumentCouldBeFinal.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FormalArgumentCouldBeFinal.java
@@ -16,9 +16,9 @@ import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 import net.sourceforge.pmd.lang.symboltable.Scope;
 
-public class MethodArgumentCouldBeFinalRule extends AbstractOptimizationRule {
+public class FormalArgumentCouldBeFinal extends AbstractOptimizationRule {
 
-    public MethodArgumentCouldBeFinalRule() {
+    public FormalArgumentCouldBeFinal() {
         addRuleChainVisit(ASTConstructorDeclaration.class);
         addRuleChainVisit(ASTMethodDeclaration.class);
     }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/FormalParameterCouldBeFinalTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/FormalParameterCouldBeFinalTest.java
@@ -6,6 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.codestyle;
 
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
-public class MethodArgumentCouldBeFinalTest extends PmdRuleTst {
+public class FormalParameterCouldBeFinalTest extends PmdRuleTst {
     // no additional unit tests
 }


### PR DESCRIPTION
## Describe the PR

Renamed the rule MethodArgumentCouldBeFinal to FormalParameterCouldBeFinal. 
Also renamed the test class/method for MethodArgumentCouldBeFinalTest to FormalParameterCouldBeFinalTest to add consistency. 

## Related issues


- Fixes #11 

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

